### PR TITLE
fix: camel_to_snake(P2P) should return p2p

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,16 @@ matrix:
         - pip install pipenv
         - pipenv install --dev
       script:
+        - pipenv run python --version
+        - make ci-python
+    - name: Python (2.7)
+      language: python
+      python: '2.7'
+      install:
+        - pip install pipenv
+        - pipenv install --dev
+      script:
+        - pipenv run python --version
         - make ci-python
 
 before_cache:

--- a/cfb/context.py
+++ b/cfb/context.py
@@ -4,8 +4,8 @@ from cfb.reflection.BaseType import BaseType
 from cfb.constants import SIZE_OF_UOFFSET, BASE_TYPE_SIZE, BASE_TYPE_RUST_TYPE, BASE_TYPE_DEFAULT, RESERVED_KEYWORDS
 from cfb.struct import struct_padded_fields
 
-FIRST_CAP_RE = re.compile('(.)([A-Z][a-z]+)')
-ALL_CAP_RE = re.compile('([a-z0-9])([A-Z])')
+CAMEL_TO_SNAKE_RE = re.compile(r'(?<=[a-z])[A-Z]|[A-Z](?=[^A-Z])')
+
 
 class Context(object):
     def __init__(self, basename, schema):
@@ -208,8 +208,7 @@ class Context(object):
         return list(sorted((object.Fields(i) for i in range(object.FieldsLength())), key=lambda f: f.Offset()))
 
     def camel_to_snake(_self, name):
-        s1 = FIRST_CAP_RE.sub(r'\1_\2', name)
-        return ALL_CAP_RE.sub(r'\1_\2', s1).lower()
+        return CAMEL_TO_SNAKE_RE.sub(r'_\g<0>', name).strip('_').lower()
 
     def safe_name(_self, name):
         return RESERVED_KEYWORDS.get(name, name)

--- a/cfb/test_context.py
+++ b/cfb/test_context.py
@@ -1,0 +1,26 @@
+from os import path
+from unittest import TestCase
+from cfb.reflection.Schema import Schema
+from cfb.context import Context
+
+
+class TestContext(TestCase):
+    def schema(self):
+        dir_path = path.join(path.dirname(path.dirname(path.realpath(
+            __file__))), 'tests', 'common', 'ckb.bfbs')
+        with open(dir_path, 'rb') as bfbs_file:
+            buf = bytearray(bfbs_file.read())
+            return Schema.GetRootAsSchema(buf, 0)
+
+    def setUp(self):
+        self.context = Context('ckb', self.schema())
+
+    def testCamelToSnake(self):
+        self.assertEqual('test_camel_to_snake',
+                         self.context.camel_to_snake('testCamelToSnake'))
+        self.assertEqual('html', self.context.camel_to_snake('HTML'))
+        self.assertEqual('html_page', self.context.camel_to_snake('HTMLPage'))
+        self.assertEqual('out_html', self.context.camel_to_snake('OutHTML'))
+        self.assertEqual(
+            'out_html_page', self.context.camel_to_snake('OutHTMLPage'))
+        self.assertEqual('p2p', self.context.camel_to_snake('P2P'))


### PR DESCRIPTION
Handle acronyms in function `camel_to_snake`.

Refs https://github.com/nervosnetwork/p2p/pull/84